### PR TITLE
fix

### DIFF
--- a/contracts/FILGovernance.sol
+++ b/contracts/FILGovernance.sol
@@ -61,7 +61,7 @@ contract FILGovernance is ERC20 {
         emit Minted(account, _msgSender(), amount);
     }
 
-    function burn(uint256 amount) external onlyManagerOrBurner {
+    function burn(uint256 amount) external {
         address sender = _msgSender();
         _burn(sender, amount);
         emit Burnt(sender, amount);


### PR DESCRIPTION
The original interface is awkward, there's no need for `onlyManagerOrBurner` if it can only burn from `_msgSender()`.