### PR TITLE
fix: erc20 hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ BatchTransfer.sol
 *.sh
 gen_abi.sh
 remix-compiler.config.js
+.deps/
+DeployParameters.json

--- a/compiler_config.json
+++ b/compiler_config.json
@@ -6,6 +6,7 @@
 			"enabled": true,
 			"runs": 200
 		},
+		"viaIR": true,
 		"outputSelection": {
 			"*": {
 			"": ["ast"],

--- a/contracts/FILGovernance.sol
+++ b/contracts/FILGovernance.sol
@@ -132,7 +132,7 @@ contract FILGovernance is ERC20 {
         return tokens * 10 ** decimals();
     }
 
-    function _afterTokenTransfer(address, address, uint256) internal view {
+    function _afterTokenTransfer(address, address, uint256) internal override view {
         require(totalSupply() <= _withDecimal(MAX_SUPPLY), "Total supply cannot exceed max supply.");
     }
 }

--- a/contracts/FILTrust.sol
+++ b/contracts/FILTrust.sol
@@ -97,7 +97,7 @@ contract FILTrust is ERC20 {
         _;
     }
 
-    function _beforeTokenTransfer(address from, address to, uint) internal view {
+    function _beforeTokenTransfer(address from, address to, uint) internal override view {
         require(_manageAddresses[to] || lastMintHeight[from] + MIN_LOCKING_PERIOD <= block.number, "Just minted");
     }
 }

--- a/contracts/MultiSignFactory.sol
+++ b/contracts/MultiSignFactory.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.19;
 
 import "@openzeppelin/contracts/utils/Context.sol";
-import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
 contract MultiSignFactory is Context, ReentrancyGuard {
     enum approveResult {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "typechain": "^8.3.0"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^5.0.2",
+    "@openzeppelin/contracts": "^4.9.6",
     "@prb/math": "^4.0.2",
     "filecoin-solidity-api": "^1.1.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -792,10 +792,10 @@
     ethers "^4.0.0-beta.1"
     source-map-support "^0.5.19"
 
-"@openzeppelin/contracts@^5.0.2":
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-5.0.2.tgz#b1d03075e49290d06570b2fd42154d76c2a5d210"
-  integrity sha512-ytPc6eLGcHHnapAZ9S+5qsdomhjo6QBHTDRRBFfTxXIpsicMhVPouPgmUPebZZZGX7vt9USA+Z+0M0dSVtSUEA==
+"@openzeppelin/contracts@^4.9.6":
+  version "4.9.6"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.6.tgz#2a880a24eb19b4f8b25adc2a5095f2aa27f39677"
+  integrity sha512-xSmezSupL+y9VkHZJGDoCBpmnB2ogM13ccaYDWqJTfS3dbuHkgjuwDFUmaFauBCboQMGB/S5UqUl2y54X99BmA==
 
 "@prb/math@^4.0.2":
   version "4.0.2"


### PR DESCRIPTION
1.use correct version of openziline/contracts/tokens/erc20
erc20 contracts has multi versions:
- the version of 5.0.2 has not implement the hooks of `_beforeTokenTransfer` and `_afterTokenTransfer`
- the version of 4.9.6 has implement the hooks

contract of Fitrust use the hook of `_beforeTotenTransfer` to avoid dumplicate `deposit` with fil token in 1 day.
contract of FilGovernance use the hook of `_afterTokenTransfer` to confirm total supply is correct.

2.multiSignFactory depend ReentrancyGuard by correct version and path

3.update package.json and yarn.lock for building

4.fix remix compile error "stack too deep", select "compile with compile_config.json" to build with remixd

5.add deps and DeployParameters.json at gitignore for tests

6.test the new content


