### PR TITLE
update claim

### DIFF
--- a/contracts/BatchTransfer.sol
+++ b/contracts/BatchTransfer.sol
@@ -24,8 +24,6 @@ contract BatchTransfer is Context {
 
         if (asset == nativeToken) {
             require(msg.value >= total, "Invalid amount");
-        } else {
-            require(_token.allowance(spender, address(this)) >= total, "Not enough allowance");
         }
 
         for (uint256 i = 0; i < recipients.length; i++) {

--- a/contracts/Claim.sol
+++ b/contracts/Claim.sol
@@ -2,14 +2,12 @@
 pragma solidity ^0.8.19;
 
 import "@openzeppelin/contracts/utils/Context.sol";
-import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract Claim is Context, ReentrancyGuard {
     
-    using SafeERC20 for IERC20;
-
     // the actions that can be claimed
     enum Action {
         Unknown,
@@ -24,7 +22,7 @@ contract Claim is Context, ReentrancyGuard {
     }
 
     address public immutable _reserve;     // the reserve address, the rest token will be sent to this address  
-    IERC20 public immutable _token;
+    ERC20 public immutable _token;
 
     mapping (Action => uint) public _supplies;                              // mapping action to the supply
     mapping (Action => bytes32) public _merkleRoots;                        // mapping action to the merkle root
@@ -77,7 +75,7 @@ contract Claim is Context, ReentrancyGuard {
 
     constructor(address token, address reserve, bytes32[] memory merkleRoots, uint[] memory userNums) {
         _reserve = reserve;
-        _token = IERC20(token);
+        _token = ERC20(token);
 
         // set up the merkle roots and user numbers, the first action is unkown
         require(merkleRoots.length == userNums.length && userNums.length == CLAIMABLE_ACTIONS, "Claim: invalid length");
@@ -113,7 +111,7 @@ contract Claim is Context, ReentrancyGuard {
 
         uint restBalance = _token.balanceOf(address(this));
         if (restBalance > 0) {
-            _token.safeTransfer(_reserve, restBalance);
+            _token.transfer(_reserve, restBalance);
         }
         return restBalance;
     }
@@ -125,7 +123,7 @@ contract Claim is Context, ReentrancyGuard {
         address account = _msgSender();
         CalculateResult memory r = calculateStake(account, requests);
         if (r.sum > 0) {
-            _token.safeTransfer(account, r.sum);
+            _token.transfer(account, r.sum);
         }
         for (uint i = 0; i < r.data.length; i++) {
             CalculateData memory item = r.data[i];
@@ -143,7 +141,7 @@ contract Claim is Context, ReentrancyGuard {
         address account = _msgSender();
         CalculateResult memory r = calculateBorrow(account, requests);
         if (r.sum > 0) {
-            _token.safeTransfer(account, r.sum);
+            _token.transfer(account, r.sum);
         }
         for (uint i = 0; i < r.data.length; i++) {
             CalculateData memory item = r.data[i];

--- a/contracts/Claim.sol
+++ b/contracts/Claim.sol
@@ -2,17 +2,20 @@
 pragma solidity ^0.8.19;
 
 import "@openzeppelin/contracts/utils/Context.sol";
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
-contract Claim is Context {
+contract Claim is Context, ReentrancyGuard {
+    
+    using SafeERC20 for IERC20;
 
     // the actions that can be claimed
     enum Action {
         Unknown,
         FigBalance,             // 1
         FitGovernance,          // 2
-        DiscordPharse2,         // 3
+        DiscordPhase2,          // 3
         DiscordLevel5,          // 4
         MinerBorrow,            // 5
         MinerPayback,           // 6
@@ -20,21 +23,20 @@ contract Claim is Context {
         ActionEnd               // 8 
     }
 
-    address private _fundation;   // the owner of the contract, which is an multi-sig address
-    address private _reserve;     // the reserve address, the rest token will be sent to this address  
-    ERC20 private _token;
+    address public immutable _reserve;     // the reserve address, the rest token will be sent to this address  
+    IERC20 public immutable _token;
 
-    mapping (Action => uint) private _supplys;                              // mapping action to the supply
-    mapping (Action => bytes32) private _merkleRoots;                       // mapping action to the merkle root
-    mapping (address => mapping (Action => bool)) private _claimeds;        // mapping address to the claim status
-    mapping (address => mapping (Action => uint)) private _withdrawns;      // mapping address to the withdraw status
-    mapping (Action => uint) private _stats;                                // mapping action to the number of users
+    mapping (Action => uint) public _supplies;                              // mapping action to the supply
+    mapping (Action => bytes32) public _merkleRoots;                        // mapping action to the merkle root
+    mapping (address => mapping (Action => bool)) public _claimeds;         // mapping address to the claim status
+    mapping (address => mapping (Action => uint)) public _withdrawns;       // mapping address to the withdraw status
+    mapping (Action => uint) public _stats;                                 // mapping action to the number of users
 
     // the supplys of the claimable actions
     uint constant SUPPLY_UNIT = 10000 * 1e18;
     uint constant FIG_BALANCE_SUPPLY = 500 * SUPPLY_UNIT;
     uint constant FIT_GOVERNANCE_SUPPLY = 60 * SUPPLY_UNIT;
-    uint constant DISCORD_PHARSE2_SUPPLY = 90 * SUPPLY_UNIT;
+    uint constant DISCORD_PHASE2_SUPPLY = 90 * SUPPLY_UNIT;
     uint constant DISCORD_LEVEL5_SUPPLY = 150 * SUPPLY_UNIT;
     uint constant MINER_BORROW_SUPPLY = 100 * SUPPLY_UNIT;
     uint constant MINER_PAYBACK_SUPPLY = 60 * SUPPLY_UNIT;
@@ -51,7 +53,7 @@ contract Claim is Context {
     // the number of actions
     bool private _once;    // check balance only once
     uint private CLAIMABLE_ACTIONS = uint(Action.ActionEnd) - 1;
-    uint _supplySum = FIG_BALANCE_SUPPLY + FIT_GOVERNANCE_SUPPLY + DISCORD_PHARSE2_SUPPLY + DISCORD_LEVEL5_SUPPLY + MINER_BORROW_SUPPLY + MINER_PAYBACK_SUPPLY + MINER_BORROW_TWICE_SUPPLY;
+    uint _supplySum = FIG_BALANCE_SUPPLY + FIT_GOVERNANCE_SUPPLY + DISCORD_PHASE2_SUPPLY + DISCORD_LEVEL5_SUPPLY + MINER_BORROW_SUPPLY + MINER_PAYBACK_SUPPLY + MINER_BORROW_TWICE_SUPPLY;
 
     // the data structure of the claim request
     struct Request {
@@ -73,10 +75,9 @@ contract Claim is Context {
     event Claimed(address indexed account, uint amount);
     event Withdrawn(address indexed account, uint amount);
 
-    constructor(address token, address fundation, address reserve, bytes32[] memory merkleRoots, uint[] memory userNums) {
-        _fundation = fundation;
+    constructor(address token, address reserve, bytes32[] memory merkleRoots, uint[] memory userNums) {
         _reserve = reserve;
-        _token = ERC20(token);
+        _token = IERC20(token);
 
         // set up the merkle roots and user numbers, the first action is unkown
         require(merkleRoots.length == userNums.length && userNums.length == CLAIMABLE_ACTIONS, "Claim: invalid length");
@@ -92,46 +93,37 @@ contract Claim is Context {
         _airdropEndBlock = _startBlock + AIRDROP_LAST_BLOCK;
 
         // setting up the supplys
-        _supplys[Action.FigBalance] = FIG_BALANCE_SUPPLY;
-        _supplys[Action.FitGovernance] = FIT_GOVERNANCE_SUPPLY;
-        _supplys[Action.DiscordPharse2] = DISCORD_PHARSE2_SUPPLY;
-        _supplys[Action.DiscordLevel5] = DISCORD_LEVEL5_SUPPLY;
-        _supplys[Action.MinerBorrow] = MINER_BORROW_SUPPLY;
-        _supplys[Action.MinerPayback] = MINER_PAYBACK_SUPPLY;
-        _supplys[Action.MinerBorrowTwice] = MINER_BORROW_TWICE_SUPPLY;
+        _supplies[Action.FigBalance] = FIG_BALANCE_SUPPLY;
+        _supplies[Action.FitGovernance] = FIT_GOVERNANCE_SUPPLY;
+        _supplies[Action.DiscordPhase2] = DISCORD_PHASE2_SUPPLY;
+        _supplies[Action.DiscordLevel5] = DISCORD_LEVEL5_SUPPLY;
+        _supplies[Action.MinerBorrow] = MINER_BORROW_SUPPLY;
+        _supplies[Action.MinerPayback] = MINER_PAYBACK_SUPPLY;
+        _supplies[Action.MinerBorrowTwice] = MINER_BORROW_TWICE_SUPPLY;
 
         _once = false;
     }
     
-    // if the contract deployed with the wrong merkle root, the owner can reset it
-    function setMerkleRoot(Action act, bytes32 root) external onlyFundation {
-        _merkleRoots[act] = root;
-    }
-    // if the contract deployed with the wrong user number, the owner can reset it
-    function setUserNum(Action act, uint num) external onlyFundation {
-        _stats[act] = num;
-    }
-
     // if the contract has some token left, the owner can retrive it after the airdrop end
     // anyone can call this function
-    function retrive() external payable returns (uint) {
+    function retrieve() external returns (uint) {
         require(block.number > _airdropEndBlock, "Claim: not reach the end block");
 
         uint restBalance = _token.balanceOf(address(this));
         if (restBalance > 0) {
-            _token.transfer(_reserve, restBalance);
+            _token.safeTransfer(_reserve, restBalance);
         }
         return restBalance;
     }
 
-    // user paritipant test1,test3 governance and discord can be claimed, and user will get the reward
-    function claim(Request[] calldata requests) expire() external payable returns (uint) {
+    // user participant governance and discord can be claimed, and user will get the reward
+    function claim(Request[] calldata requests) expire nonReentrant external returns (uint) {
         _checkBalance();
 
         address account = _msgSender();
         CalculateResult memory r = calculateStake(account, requests);
         if (r.sum > 0) {
-            _token.transfer(account, r.sum);
+            _token.safeTransfer(account, r.sum);
         }
         for (uint i = 0; i < r.data.length; i++) {
             CalculateData memory item = r.data[i];
@@ -143,13 +135,13 @@ contract Claim is Context {
     }
 
     // user borrow and payback FIL token can be withdrawn, and user will get the reward
-    function withdraw(Request[] calldata requests) expire() external payable returns (uint) {        
+    function withdraw(Request[] calldata requests) expire nonReentrant external returns (uint) {        
         _checkBalance();
 
         address account = _msgSender();
         CalculateResult memory r = calculateBorrow(account, requests);
         if (r.sum > 0) {
-            _token.transfer(account, r.sum);
+            _token.safeTransfer(account, r.sum);
         }
         for (uint i = 0; i < r.data.length; i++) {
             CalculateData memory item = r.data[i];
@@ -249,7 +241,7 @@ contract Claim is Context {
     }
 
     function _calculate(Action act) private view returns (uint) {
-        uint supply = _supplys[act];
+        uint supply = _supplies[act];
         uint userCnt = _stats[act];
         return supply / userCnt;
     }
@@ -274,7 +266,7 @@ contract Claim is Context {
     }
 
     function _isStakeAction(Action act) private pure returns (bool) {
-        return act == Action.FigBalance || act == Action.FitGovernance || act == Action.DiscordPharse2 || act == Action.DiscordLevel5;
+        return act == Action.FigBalance || act == Action.FitGovernance || act == Action.DiscordPhase2 || act == Action.DiscordLevel5;
     }
 
     function _isBorrowAction(Action act) private pure returns (bool) {
@@ -295,11 +287,6 @@ contract Claim is Context {
 
     modifier expire() {
         require(_checkTime(), "Claim: airdrop expired");
-        _;
-    }
-
-    modifier onlyFundation() {
-        require(msg.sender == _fundation, "Only owner can call this function");
         _;
     }
 }


### PR DESCRIPTION
batchTransfer contract updated comments:
- delete owner and managers for `batchTransfer`;
- add native token transfer for `batchTransfer`;
- use library `safeERC20` instead of `ERC20`;
- delete useless `allowance` checking;
- add interface for query miner balances with miner identity list;

claim contract updated comments:
- delete owner and foundation, `setMerkleRoots` and `setUserNumber` are forbidden;
- add library of `ReentrancyGuard`, functions of `claim`, `withdraw` should use `nonReentrant` modifier to avoid the risk of calling unknown contracts;
- update variables to be immutable;
- update variables to be public;
- use `stats` to record the reward of each single user at the single action, calculate the single reward in _constructor but  not `_calculate`;
- update some incorrect typos, e.g: DiscordPharse, _supplys