### PR TITLE
implement `static` functions, e.g: getTVl

### DIFF
--- a/contracts/Static.sol
+++ b/contracts/Static.sol
@@ -9,36 +9,27 @@ contract Static {
     
     FILLiquidInterface public _filliquid;
 
-    struct TVLData {
-        uint minerNum;                  // all miners in `fil-liquid` subset
-        uint collaterizedMinerNum;      // miners still bound in `fil-liquid`
-        uint totalLockedMinerBalance;   // total locked FIL balance of collaterized miners
-        uint totalFILLiquidity;         // total FIL liquidity in `fil-liquid`
-        uint availableFILLiquidity;     // available FIL liquidity in `fil-liquid`
-        uint TVL;                       // the sum of `totalLockedMinerBalance` and `availableFILLiquidity`
-    }
-
     constructor(address filliquid) {
         _filliquid = FILLiquidInterface(filliquid);
     }
 
-    function getTVL() external view returns (TVLData memory data) {
+    function getTVL() external view returns (uint minerNum, uint collaterizedMinerNum, uint totalLockedMinerBalance, uint totalFILLiquidity, uint availableFILLiquidity, uint tvl) {
         uint start = 0;
         uint end = _filliquid.allMinersCount();
-        data.minerNum = end;
+        minerNum = end;
 
         FILLiquid.BindStatusInfo[] memory allMiners = _filliquid.allMinersSubset(start, end);
         for (uint j = 0; j < allMiners.length; j++) {
             FILLiquid.BindStatusInfo memory info = allMiners[j];
             if (!info.status.stillBound) continue;
-            data.collaterizedMinerNum++;
-            data.totalLockedMinerBalance += minerBalance(info.minerId);
+            collaterizedMinerNum++;
+            totalLockedMinerBalance += minerBalance(info.minerId);
         }
 
         FILLiquid.FILLiquidInfo memory filLiquidInfo = _filliquid.getStatus();
-        data.totalFILLiquidity = filLiquidInfo.totalFIL;
-        data.availableFILLiquidity = filLiquidInfo.availableFIL;
-        data.TVL = data.totalLockedMinerBalance + data.availableFILLiquidity;
+        totalFILLiquidity = filLiquidInfo.totalFIL;
+        availableFILLiquidity = filLiquidInfo.availableFIL;
+        tvl = totalLockedMinerBalance + availableFILLiquidity;
     }
 
     function minerBalance(uint64 minerId) internal view returns (uint) {

--- a/contracts/Static.sol
+++ b/contracts/Static.sol
@@ -5,7 +5,7 @@ import "./FILLiquid.sol";
 
 import "filecoin-solidity-api/contracts/v0.8/utils/FilAddressIdConverter.sol";
 
-contract Statics {
+contract Static {
     
     FILLiquidInterface public _filliquid;
 

--- a/contracts/Static.sol
+++ b/contracts/Static.sol
@@ -10,11 +10,12 @@ contract Static {
     FILLiquidInterface public _filliquid;
 
     struct TVLData {
-        uint minerNum;
-        uint activeMinerNum;
-        uint minerBalance;
-        uint totalTVL;
-        uint availableTVL;
+        uint minerNum;                  // all miners in `fil-liquid` subset
+        uint collaterizedMinerNum;      // miners still bound in `fil-liquid`
+        uint totalLockedMinerBalance;   // total locked FIL balance of collaterized miners
+        uint totalFILLiquidity;         // total FIL liquidity in `fil-liquid`
+        uint availableFILLiquidity;     // available FIL liquidity in `fil-liquid`
+        uint TVL;                       // the sum of `totalLockedMinerBalance` and `availableFILLiquidity`
     }
 
     constructor(address filliquid) {
@@ -24,19 +25,20 @@ contract Static {
     function getTVL() external view returns (TVLData memory data) {
         uint start = 0;
         uint end = _filliquid.allMinersCount();
+        data.minerNum = end;
 
         FILLiquid.BindStatusInfo[] memory allMiners = _filliquid.allMinersSubset(start, end);
         for (uint j = 0; j < allMiners.length; j++) {
             FILLiquid.BindStatusInfo memory info = allMiners[j];
             if (!info.status.stillBound) continue;
-            data.activeMinerNum++;
-            data.minerBalance += minerBalance(info.minerId);
+            data.collaterizedMinerNum++;
+            data.totalLockedMinerBalance += minerBalance(info.minerId);
         }
 
         FILLiquid.FILLiquidInfo memory filLiquidInfo = _filliquid.getStatus();
-        data.minerNum = end;
-        data.totalTVL = filLiquidInfo.totalFIL;
-        data.availableTVL = filLiquidInfo.availableFIL;
+        data.totalFILLiquidity = filLiquidInfo.totalFIL;
+        data.availableFILLiquidity = filLiquidInfo.availableFIL;
+        data.TVL = data.totalLockedMinerBalance + data.availableFILLiquidity;
     }
 
     function minerBalance(uint64 minerId) internal view returns (uint) {

--- a/contracts/Statics.sol
+++ b/contracts/Statics.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "./FILLiquid.sol";
+
+import "filecoin-solidity-api/contracts/v0.8/utils/FilAddressIdConverter.sol";
+
+contract Statics {
+    
+    FILLiquidInterface public _filliquid;
+
+    struct TVLData {
+        uint minerNum;
+        uint activeMinerNum;
+        uint minerBalance;
+        uint totalTVL;
+        uint availableTVL;
+    }
+
+    constructor(address filliquid) {
+        _filliquid = FILLiquidInterface(filliquid);
+    }
+
+    function getTVL() external view returns (TVLData memory data) {
+        uint start = 0;
+        uint end = _filliquid.allMinersCount();
+
+        FILLiquid.BindStatusInfo[] memory allMiners = _filliquid.allMinersSubset(start, end);
+        for (uint j = 0; j < allMiners.length; j++) {
+            FILLiquid.BindStatusInfo memory info = allMiners[j];
+            if (!info.status.stillBound) continue;
+            data.activeMinerNum++;
+            data.minerBalance += minerBalance(info.minerId);
+        }
+
+        FILLiquid.FILLiquidInfo memory filLiquidInfo = _filliquid.getStatus();
+        data.minerNum = end;
+        data.totalTVL = filLiquidInfo.totalFIL;
+        data.availableTVL = filLiquidInfo.availableFIL;
+    }
+
+    function minerBalance(uint64 minerId) internal view returns (uint) {
+        return toAddress(minerId).balance;
+    }
+    
+    function toAddress(uint64 actorId) internal view returns (address) {
+        return FilAddressIdConverter.toAddress(actorId);
+    }
+}


### PR DESCRIPTION
The `defillama` website is famous for various `defi TVL` rankings.

How to access `defilama`:
1.fork the repo of `github.com/DefiLlama/DefiLlama-Adapters` to your own git repository;
2.add folder which named as your `defi` project into projects.
3.fetch the `defi tvl` with on chain calculation.
4.submit the pull request to the adapters and waiting for tests and merging.
5.after that, the TVL of your DeFi project will be displayed on the website.

the contract of `static` will get available tvl and the sum of miners balance from `fil-liquid`, and the interface of `getTVL` will be used in the adapter.